### PR TITLE
Explicit metric types

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ if (cluster.isMaster) {
 }
 ```
 
-### A warning about `metrics.describe()` and Node's `cluster` module
+### A warning about `metrics.describe` and Node's `cluster` module
 
-When you make a call to `metrics.describe()`, a global registry object is updated with the 
-metric's description. If you call `metrics.describe()` in the master before forking, the
+When you make a call to `metrics.describe.counter()` (or `metrics.describe.histogram()`, etc.)
+, a global registry object is updated with the metric's description. If you call 
+`metrics.describe.counter()` in the master before forking, the
 registries inside the workers will not have the metric definition, and because you can write
 to a metric without first describing it, this means it will simply have all defaults, and not
 your custom description, labels, buckets, percentiles, etc...
@@ -160,10 +161,10 @@ Descriptions can be used to inform prometheus / the client library about the met
 
 ### Help text
 
-Metrics can be given a help text using syntax like the following:
+Metrics description calls specify the type of the metric, its name, and a description, at minimum:
 
 ```
-metrics.describe(
+metrics.describe.histogram(
     'api_request_duration_milliseconds',
     'histogram of total time taken to service requests to the api including queue wait (all queues and all userAgents together)',
 );
@@ -174,7 +175,7 @@ metrics.describe(
 This is where labels would be specified as well:
 
 ```
-metrics.describe(
+metrics.describe.histogram(
     'api_request_duration_milliseconds',
     'histogram of total time taken to service requests to the api including queue wait (all queues and all userAgents together)',
     {
@@ -185,12 +186,11 @@ metrics.describe(
 
 ### Histogram buckets and Summary percentiles
 
-You can also use `.describe()` to declare buckets for histogram-type metrics or
-percentiles for summary-type metrics, if you'd like them to differ from the defaults:
+You can also declare buckets for histogram-type metrics or percentiles for summary-type metrics, if you'd like them to differ from the defaults:
 
 **histogram buckets**
 ```
-metrics.describe(
+metrics.describe.histogram(
     'api_request_duration_milliseconds',
     'histogram of total time taken to service requests to the api including queue wait',
     {
@@ -202,7 +202,7 @@ metrics.describe(
 
 **summary percentiles**
 ```
-metrics.describe(
+metrics.describe.summary(
     'api_request_duration_milliseconds',
     'summary of total time taken to service requests to the api including queue wait',
     {
@@ -255,7 +255,7 @@ deviated from the average (which would be `total / nWorkers`), we could also
 record a gauge which had been described with the `max` aggregation strategy:
 
 ```
-metrics.describe(
+metrics.describe.gauge(
     'active_connections_max',
     'the number of connections being handled by the busiest worker',
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import * as express from 'express';
 import * as prometheus from 'prom-client';
 
 import { AggregatorStrategy } from './enums';
@@ -6,25 +7,12 @@ export interface LabelSet {
 	[name: string]: string;
 }
 
-export interface DescriptionMap {
-	[name: string]: string;
-}
-
-export interface ExistMap {
-	[name: string]: boolean;
-}
-
 export interface CustomParams {
 	percentiles?: number[];
 	buckets?: number[];
 	labelNames?: string[];
 	aggregator?: AggregatorStrategy;
 }
-
-export interface CustomParamsMap {
-	[name: string]: CustomParams;
-}
-
 // weird class to allow polymorphism over constructors yielding type Metric
 export class MetricConstructor {
 	constructor(public construct: new (...args: any[]) => prometheus.Metric) {}
@@ -42,9 +30,18 @@ export interface MetricsMap {
 	counter: { [name: string]: prometheus.Counter };
 	histogram: { [name: string]: prometheus.Histogram };
 	summary: { [name: string]: prometheus.Summary };
-	[kind: string]: { [name: string]: prometheus.Metric };
 }
 
-export interface KindMap {
-	[name: string]: string;
+export type Kind = keyof MetricsMap;
+
+export interface MetricsMeta {
+	kind: Kind;
+	help: string;
+	customParams: CustomParams;
 }
+
+export interface MetricsMetaMap {
+	[name: string]: MetricsMeta;
+}
+
+export type AuthTestFunc = (req: express.Request) => boolean;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -44,15 +44,82 @@ describe('Gauge', () => {
 		output = metrics.output();
 		expect(/undescribed_gauge 1/.test(output)).to.be.true;
 	});
+});
 
-	it('should throw an error on inc() to histogram, summary', () => {
+describe('Counter', () => {
+	it('should create a counter', () => {
+		metrics.describe.counter('existent_counter', 'a counter that should exist');
+		metrics.counter('existent_counter');
+		const output = metrics.output();
+		expect(/TYPE existent_counter counter/.test(output)).to.be.true;
+	});
+
+	it('should reset a counter', () => {
+		metrics.describe.counter(
+			'resetting_counter',
+			'a counter that should be reset',
+		);
+		metrics.counter('resetting_counter');
+		metrics.reset('resetting_counter');
+		const output = metrics.output();
+		expect(/resetting_counter 0/.test(output)).to.be.true;
+	});
+
+	it('should increment by 1 if not specified', () => {
+		metrics.describe.counter('simple_counter', 'a simple counter');
+		metrics.counter('simple_counter');
+		const output = metrics.output();
+		expect(/simple_counter 1/.test(output)).to.be.true;
+	});
+
+	it('should increment by a variable amount', () => {
+		metrics.describe.counter(
+			'variable_counter',
+			'a counter that should increment by variable amounts',
+		);
+		metrics.counter('variable_counter', 1);
+		metrics.inc('variable_counter', 3);
+		const output = metrics.output();
+		expect(/variable_counter 4/.test(output)).to.be.true;
+	});
+
+	it('should throw an error on dec() to counter', () => {
 		expectToErr(() => {
-			metrics.histogram('histogram_metric', 1);
-			metrics.inc('histogram_metric');
+			metrics.counter('counter_metric', 1);
+			metrics.dec('counter_metric');
 		});
+	});
+});
+
+describe('Summary', () => {
+	it('should throw an error on inc() to summary', () => {
 		expectToErr(() => {
 			metrics.summary('summary_metric', 1);
 			metrics.inc('summary_metric');
+		});
+	});
+
+	it('should throw an error on dec() to summary', () => {
+		expectToErr(() => {
+			metrics.summary('summary_metric', 1);
+			metrics.dec('summary_metric');
+		});
+	});
+
+	it('should allow single-line CustomParams', () => {
+		const percentiles = [0.1, 0.5, 0.9];
+		metrics.summary('summary_metric', 1, {}, { percentiles });
+		expect(metrics.meta['summary_metric'].customParams.percentiles).to.eql(
+			percentiles,
+		);
+	});
+});
+
+describe('Histogram', () => {
+	it('should throw an error on inc() to histogram', () => {
+		expectToErr(() => {
+			metrics.histogram('histogram_metric', 1);
+			metrics.inc('histogram_metric');
 		});
 	});
 
@@ -61,48 +128,13 @@ describe('Gauge', () => {
 			metrics.histogram('histogram_metric', 1);
 			metrics.dec('histogram_metric');
 		});
-		expectToErr(() => {
-			metrics.summary('summary_metric', 1);
-			metrics.dec('summary_metric');
-		});
-		expectToErr(() => {
-			metrics.counter('counter_metric', 1);
-			metrics.dec('counter_metric');
-		});
-	});
-});
-
-describe('Counter', () => {
-	it('should create a counter', () => {
-		metrics.describe('existent_counter', 'a counter that should exist');
-		metrics.counter('existent_counter');
-		const output = metrics.output();
-		expect(/TYPE existent_counter counter/.test(output)).to.be.true;
 	});
 
-	it('should reset a counter', () => {
-		metrics.describe('resetting_counter', 'a counter that should be reset');
-		metrics.counter('resetting_counter');
-		metrics.reset('resetting_counter');
-		const output = metrics.output();
-		expect(/resetting_counter 0/.test(output)).to.be.true;
-	});
-
-	it('should increment by 1 if not specified', () => {
-		metrics.describe('simple_counter', 'a simple counter');
-		metrics.counter('simple_counter');
-		const output = metrics.output();
-		expect(/simple_counter 1/.test(output)).to.be.true;
-	});
-
-	it('should increment by a variable amount', () => {
-		metrics.describe(
-			'variable_counter',
-			'a counter that should increment by variable amounts',
+	it('should allow single-line CustomParams', () => {
+		const buckets = [1, 9, 99, 999];
+		metrics.histogram('histogram_metric', 1, {}, { buckets });
+		expect(metrics.meta['histogram_metric'].customParams.buckets).to.eql(
+			buckets,
 		);
-		metrics.counter('variable_counter', 1);
-		metrics.inc('variable_counter', 3);
-		const output = metrics.output();
-		expect(/variable_counter 4/.test(output)).to.be.true;
 	});
 });

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "tslint-no-unused-expression-chai"
+  ]
+}


### PR DESCRIPTION
Metric types to be specified at describe-time (major API change from `.describe()` to `.describe.${type}()`, for example `.describe.histogram()`).
Also simplified handling of metrics metadata internal to the class