### PR TITLE
error-protect all class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,3 +271,7 @@ on('disconnect', () => {
     metrics.gauge('active_connections_max', nConnections);
 });
 ```
+
+### Internal errors
+
+Errors occuring in calls to this library are caught, logged to stderr if the `DEBUG` env var is defined, and a public property of the MetricsGatherer object will be incremented: `internalErrorCount`.

--- a/src/metrics-gatherer.ts
+++ b/src/metrics-gatherer.ts
@@ -29,6 +29,7 @@ const constructors: ConstructorMap = {
 };
 
 export class MetricsGatherer {
+	public internalErrorCount: number;
 	private metrics: MetricsMap;
 	private customParams: CustomParamsMap;
 	private descriptions: DescriptionMap;
@@ -40,90 +41,131 @@ export class MetricsGatherer {
 	}
 
 	private initState() {
-		this.metrics = {
-			gauge: {},
-			counter: {},
-			summary: {},
-			histogram: {},
-		};
-		this.customParams = {};
-		this.descriptions = {};
-		this.existMap = {};
-		this.kinds = {};
+		try {
+			this.metrics = {
+				gauge: {},
+				counter: {},
+				summary: {},
+				histogram: {},
+			};
+			this.customParams = {};
+			this.descriptions = {};
+			this.existMap = {};
+			this.kinds = {};
+			this.internalErrorCount = 0;
+		} catch (e) {
+			this.err(e);
+		}
 	}
 
 	// fetch the description for a metric
 	public describe(name: string, text: string, custom: CustomParams = {}) {
-		if (this.descriptions[name]) {
-			throw new MetricsGathererError(
-				`tried to describe metric "${name}" twice`,
-			);
+		try {
+			if (this.descriptions[name]) {
+				throw new MetricsGathererError(
+					`tried to describe metric "${name}" twice`,
+				);
+			}
+			this.descriptions[name] = text;
+			this.customParams[name] = custom;
+		} catch (e) {
+			this.err(e);
 		}
-		this.descriptions[name] = text;
-		this.customParams[name] = custom;
 	}
 
 	// observe a gauge metric
 	public gauge(name: string, val: number, labels: LabelSet = {}) {
-		this.ensureExists(name, 'gauge', labels);
-		this.metrics.gauge[name].set(labels, val);
+		try {
+			this.ensureExists(name, 'gauge', labels);
+			this.metrics.gauge[name].set(labels, val);
+		} catch (e) {
+			this.err(e);
+		}
 	}
 
 	// increment a counter or gauge
 	public inc(name: string, val: number = 1, labels: LabelSet = {}) {
-		// ensure either that this metric already exists, or if not, create a gauge
-		this.ensureExists(name, 'gauge', labels);
-		if (!this.checkMetricType(name, ['gauge', 'counter'])) {
-			throw new MetricsGathererError(
-				`Tried to increment non-gauge, non-counter metric ${name}`,
-			);
-		}
-		if (this.kinds[name] === 'gauge') {
-			this.metrics.gauge[name].inc(labels, val);
-		} else {
-			this.metrics.counter[name].inc(labels, val);
+		try {
+			// ensure either that this metric already exists, or if not, create a gauge
+			this.ensureExists(name, 'gauge', labels);
+			if (!this.checkMetricType(name, ['gauge', 'counter'])) {
+				throw new MetricsGathererError(
+					`Tried to increment non-gauge, non-counter metric ${name}`,
+				);
+			}
+			if (this.kinds[name] === 'gauge') {
+				this.metrics.gauge[name].inc(labels, val);
+			} else {
+				this.metrics.counter[name].inc(labels, val);
+			}
+		} catch (e) {
+			this.err(e);
 		}
 	}
 
 	// decrement a gauge
 	public dec(name: string, val: number = 1, labels: LabelSet = {}) {
-		// ensure either that this metric already exists, or if not, create a gauge
-		this.ensureExists(name, 'gauge', labels);
-		if (!this.checkMetricType(name, ['gauge'])) {
-			throw new MetricsGathererError(
-				`Tried to decrement non-gauge metric ${name}`,
-			);
+		try {
+			// ensure either that this metric already exists, or if not, create a gauge
+			this.ensureExists(name, 'gauge', labels);
+			if (!this.checkMetricType(name, ['gauge'])) {
+				throw new MetricsGathererError(
+					`Tried to decrement non-gauge metric ${name}`,
+				);
+			}
+			this.metrics.gauge[name].dec(labels, val);
+		} catch (e) {
+			this.err(e);
 		}
-		this.metrics.gauge[name].dec(labels, val);
 	}
 
 	// observe a counter metric
 	public counter(name: string, val: number = 1, labels: LabelSet = {}) {
-		this.ensureExists(name, 'counter', labels);
-		this.metrics.counter[name].inc(labels, val);
+		try {
+			this.ensureExists(name, 'counter', labels);
+			this.metrics.counter[name].inc(labels, val);
+		} catch (e) {
+			this.err(e);
+		}
 	}
 
 	// observe a summary metric
 	public summary(name: string, val: number, labels: LabelSet = {}) {
-		this.ensureExists(name, 'summary', labels);
-		this.metrics.summary[name].observe(labels, val);
+		try {
+			this.ensureExists(name, 'summary', labels);
+			this.metrics.summary[name].observe(labels, val);
+		} catch (e) {
+			this.err(e);
+		}
 	}
 
 	// observe a histogram metric
 	public histogram(name: string, val: number, labels: LabelSet = {}) {
-		this.ensureExists(name, 'histogram', labels);
-		this.metrics.histogram[name].observe(labels, val);
+		try {
+			this.ensureExists(name, 'histogram', labels);
+			this.metrics.histogram[name].observe(labels, val);
+		} catch (e) {
+			this.err(e);
+		}
 	}
 
 	// observe both a histogram and a summary, adding suffixes to differentiate
 	public histogramSummary(name: string, val: number, labels: LabelSet = {}) {
-		this.histogram(`${name}_hist`, val, labels);
-		this.summary(`${name}_summary`, val, labels);
+		try {
+			this.histogram(`${name}_hist`, val, labels);
+			this.summary(`${name}_summary`, val, labels);
+		} catch (e) {
+			this.err(e);
+		}
 	}
 
 	// check that a metric is of the given type(s)
 	public checkMetricType(name: string, kinds: string[]) {
-		return kinds.includes(this.kinds[name]);
+		try {
+			return kinds.includes(this.kinds[name]);
+		} catch (e) {
+			this.err(e);
+		}
 	}
 
 	// used declaratively to ensure a given metric of a certain kind exists,
@@ -134,40 +176,48 @@ export class MetricsGatherer {
 		labels: LabelSet = {},
 		custom: CustomParams = {},
 	) {
-		// if exists, bail early
-		if (this.existMap[name]) {
-			return;
+		try {
+			// if exists, bail early
+			if (this.existMap[name]) {
+				return;
+			}
+			// if already exists with another kind, throw error
+			if (this.kinds[name] && this.kinds[name] !== kind) {
+				throw new MetricsGathererError(
+					`tried to use ${name} twice - first as ` +
+						`${this.kinds[name]}, then as ${kind}`,
+				);
+			}
+			// if not described, describe (poorly)
+			if (!(name in this.descriptions)) {
+				this.descriptions[name] = `undescribed ${kind} metric`;
+			}
+			// if doesn't exist, create metric
+			this.metrics[kind][name] = constructors[kind].create({
+				name,
+				help: this.descriptions[name],
+				labelNames: Object.keys(labels),
+				...custom,
+				...this.customParams[name],
+			});
+			this.kinds[name] = kind;
+			this.existMap[name] = true;
+		} catch (e) {
+			this.err(e);
 		}
-		// if already exists with another kind, throw error
-		if (this.kinds[name] && this.kinds[name] !== kind) {
-			throw new MetricsGathererError(
-				`tried to use ${name} twice - first as ` +
-					`${this.kinds[name]}, then as ${kind}`,
-			);
-		}
-		// if not described, describe (poorly)
-		if (!(name in this.descriptions)) {
-			this.descriptions[name] = `undescribed ${kind} metric`;
-		}
-		// if doesn't exist, create metric
-		this.metrics[kind][name] = constructors[kind].create({
-			name,
-			help: this.descriptions[name],
-			labelNames: Object.keys(labels),
-			...custom,
-			...this.customParams[name],
-		});
-		this.kinds[name] = kind;
-		this.existMap[name] = true;
 	}
 
 	// reset a given metric by name
 	public reset(name: string) {
-		// will only have an entry in this.kinds if the metric has been observed
-		// at least once (don't need to "reset" otherwise, and avoids error in
-		// indexing)
-		if (this.kinds[name]) {
-			this.metrics[this.kinds[name]][name].reset();
+		try {
+			// will only have an entry in this.kinds if the metric has been observed
+			// at least once (don't need to "reset" otherwise, and avoids error in
+			// indexing)
+			if (this.kinds[name]) {
+				this.metrics[this.kinds[name]][name].reset();
+			}
+		} catch (e) {
+			this.err(e);
 		}
 	}
 
@@ -182,6 +232,8 @@ export class MetricsGatherer {
 		};
 	}
 
+	// create an express request handler given an auth test function which is
+	// suitable for use in a context where we're using node's `cluster` module
 	public aggregateRequestHandler(authTest?: AuthTestFunc): express.Handler {
 		const aggregatorRegistry = new prometheus.AggregatorRegistry();
 		return (req, res) => {
@@ -195,7 +247,7 @@ export class MetricsGatherer {
 					res.send(metrics);
 				})
 				.catch((err: Error) => {
-					debug(`error in /cluster_metrics: ${err}`);
+					this.err(err);
 					res.status(500).send();
 				});
 		};
@@ -203,12 +255,26 @@ export class MetricsGatherer {
 
 	// get the prometheus output
 	public output(): string {
-		return prometheus.register.metrics();
+		try {
+			return prometheus.register.metrics();
+		} catch (e) {
+			this.err(e);
+			return '';
+		}
 	}
 
 	// clear all metrics
 	public clear() {
-		prometheus.register.clear();
-		this.initState();
+		try {
+			prometheus.register.clear();
+			this.initState();
+		} catch (e) {
+			this.err(e);
+		}
+	}
+
+	private err(e: Error) {
+		debug(e.stack);
+		this.internalErrorCount++;
 	}
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -7,12 +7,18 @@ beforeEach(() => {
 	metrics.clear();
 });
 
+const expectToErr = (f: () => void) => {
+	const errsBefore = metrics.internalErrorCount;
+	f();
+	expect(metrics.internalErrorCount - errsBefore).to.equal(1);
+};
+
 describe('Error', () => {
 	it('should fail if same name used for different kinds', () => {
-		expect(() => {
+		expectToErr(() => {
 			metrics.counter('a_name', 1);
 			metrics.histogram('a_name', 1);
-		}).to.throw();
+		});
 	});
 });
 
@@ -40,29 +46,29 @@ describe('Gauge', () => {
 	});
 
 	it('should throw an error on inc() to histogram, summary', () => {
-		expect(() => {
+		expectToErr(() => {
 			metrics.histogram('histogram_metric', 1);
 			metrics.inc('histogram_metric');
-		}).to.throw();
-		expect(() => {
+		});
+		expectToErr(() => {
 			metrics.summary('summary_metric', 1);
 			metrics.inc('summary_metric');
-		}).to.throw();
+		});
 	});
 
-	it('should throw an error on dec() to non-gauge', () => {
-		expect(() => {
+	it('should throw an error on dec() to histogram', () => {
+		expectToErr(() => {
 			metrics.histogram('histogram_metric', 1);
 			metrics.dec('histogram_metric');
-		}).to.throw();
-		expect(() => {
+		});
+		expectToErr(() => {
 			metrics.summary('summary_metric', 1);
 			metrics.dec('summary_metric');
-		}).to.throw();
-		expect(() => {
+		});
+		expectToErr(() => {
 			metrics.counter('counter_metric', 1);
 			metrics.dec('counter_metric');
-		}).to.throw();
+		});
 	});
 });
 


### PR DESCRIPTION
Re: the discussion here: https://github.com/balena-io/resin-builder/pull/632#discussion_r290943694

One change from the proposal at the end of that thread: I've used a simple counter on the object instead of a call to `this.counter(some_metrics_name, 1);` because that'll cause the stack to explode and the process to die if the error was in `this.counter()`, the exact opposite of what we want to do: protect the end-user from any internal errors which would cause an exception to be thrown.

Change-type: patch
Signed-off-by: Nick Payne <nickp@balena.io>