### PR TITLE
add behaviour to auto-detect a counter based on _total suffix

### DIFF
--- a/src/metrics-gatherer.ts
+++ b/src/metrics-gatherer.ts
@@ -98,8 +98,11 @@ export class MetricsGatherer {
 	// increment a counter or gauge
 	public inc(name: string, val: number = 1, labels: LabelSet = {}) {
 		try {
-			// ensure either that this metric already exists, or if not, create a gauge
-			this.ensureExists('gauge', name, labels);
+			// ensure either that this metric already exists, or if not
+			// create either a counter if `_total` suffix is found, or
+			// a gauge otherwise
+			const kind = /.+_total$/.test(name) ? 'counter' : 'gauge';
+			this.ensureExists(kind, name, labels);
 			if (!this.checkMetricType(name, ['gauge', 'counter'])) {
 				throw new MetricsGathererError(
 					`Tried to increment non-gauge, non-counter metric ${name}`,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -29,6 +29,12 @@ describe('Gauge', () => {
 		expect(/TYPE undescribed_gauge gauge/.test(output)).to.be.true;
 	});
 
+	it('should not create a gauge, but a counter, if _total suffix found', () => {
+		metrics.inc('build_error_total', 1);
+		const output = metrics.output();
+		expect(/TYPE build_error_total counter/.test(output)).to.be.true;
+	});
+
 	it('should inc and dec by 1 by default', () => {
 		let output: string;
 


### PR DESCRIPTION
This will mean better default behaviour, using a counter when appropriate instead of defaulting to a gauge.

Change-type: patch
Signed-off-by: dt-rush <nickp@balena.io>