### PR TITLE
measure generic, useful express API metrics by a method

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "gather / export prometheus metrics easily in nodejs",
   "main": "out/index.js",
   "scripts": {
-    "test": "npm run lint && npm run prepare && mocha --exit -r ts-node/register test/*.spec.ts",
+    "test": "npm run lint && npm run prepare && TS_NODE_FILES=true mocha --exit -r ts-node/register test/*.spec.ts",
     "build": "npx tsc --project ./tsconfig.build.json",
     "prettify": "resin-lint --typescript --fix src/ test/",
     "lint:typescript": "resin-lint --typescript src/ test/ && tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
   "dependencies": {
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.2",
+    "@types/on-finished": "^2.3.1",
     "debug": "^4.1.1",
     "express": "^4.17.1",
+    "on-finished": "^2.3.0",
     "prom-client": "^12.0.0",
     "typed-error": "^3.2.0"
   },

--- a/src/api-latency-describe.ts
+++ b/src/api-latency-describe.ts
@@ -1,0 +1,88 @@
+import { MetricsGatherer } from './metrics-gatherer';
+
+const commonLabels = ['queueName', 'userAgent', 'apiVersion'];
+
+const serviceTimePercentiles = [0.5, 0.9, 0.99, 0.999, 1.0];
+const serviceTimeBuckets = [
+	4,
+	16,
+	50,
+	100,
+	250,
+	500,
+	1000,
+	1500,
+	3000,
+	8000,
+	10000,
+	20000,
+	30000,
+];
+
+let described = false;
+
+export const describeAPIMetricsOnce = (metrics: MetricsGatherer) => {
+	if (described) {
+		return;
+	}
+	described = true;
+
+	metrics.describe.counter(
+		'api_status_code_total',
+		'number of requests with each status code',
+		{
+			labelNames: [...commonLabels, 'state', 'statusCode'],
+		},
+	);
+
+	metrics.describe.histogram(
+		'api_duration_milliseconds_hist',
+		'histogram of time spent in different phases of request handling',
+		{
+			buckets: serviceTimeBuckets,
+			labelNames: [...commonLabels, 'phase', 'state', 'statusCode'],
+		},
+	);
+
+	metrics.describe.summary(
+		'api_duration_milliseconds_summary',
+		'percentiles of time taken to service requests to the api',
+		{
+			percentiles: serviceTimePercentiles,
+			labelNames: [...commonLabels, 'phase', 'state', 'statusCode'],
+		},
+	);
+
+	metrics.describe.summary(
+		'api_duration_milliseconds_all_summary',
+		'percentiles of time taken to service requests to the api, across all queues',
+		{
+			percentiles: serviceTimePercentiles,
+			labelNames: ['state'],
+		},
+	);
+
+	metrics.describe.counter(
+		'api_arrival_total',
+		'number of arrivals to the api queues',
+		{
+			labelNames: [...commonLabels],
+		},
+	);
+
+	metrics.describe.counter(
+		'api_failure_total',
+		'number of failed requests, labeled by cause',
+		{
+			labelNames: [...commonLabels, 'cause'],
+		},
+	);
+
+	metrics.describe.counter(
+		'api_completion_total',
+		'number of requests departing the api',
+		{
+			labelNames: [...commonLabels, 'state'],
+		},
+	);
+};

--- a/src/api-latency.ts
+++ b/src/api-latency.ts
@@ -1,0 +1,60 @@
+import { NextFunction, Request, Response } from 'express';
+import * as onFinished from 'on-finished';
+
+import { MetricsGatherer } from './metrics-gatherer';
+
+const reqEndState = (req: Request): string => {
+	if (req.aborted) {
+		return 'aborted';
+	}
+	if (req.queueFailState) {
+		return req.queueFailState;
+	}
+	return 'completed';
+};
+
+// observe various metrics given a finished request
+const sampleRequestLatency = (
+	metrics: MetricsGatherer,
+	t0: ReturnType<typeof process.hrtime>,
+	req: Request,
+	res: Response,
+) => {
+	const diff = process.hrtime(t0);
+	const state = reqEndState(req);
+	const statusCode = state === 'completed' ? String(res.statusCode) : state;
+	const latency = diff[0] * 1000 + diff[1] / 1e6;
+	metrics.histogramSummary('api_duration_milliseconds', latency, {
+		...req.metricsLabels,
+		phase: 'total',
+		state,
+		statusCode,
+	});
+	// observe a second summary without any labels, for
+	// *all requests* (summaries are impossible to aggregate into a
+	// "total" like this once they're already observed into separately-
+	// -labeled summaries
+	metrics.summary('api_duration_milliseconds_all_summary', latency, {
+		state,
+	});
+	metrics.counter('api_status_code_total', 1, {
+		...req.metricsLabels,
+		state,
+		statusCode,
+	});
+	metrics.counter('api_completion_total', 1, {
+		...req.metricsLabels,
+		state,
+	});
+};
+
+export const latencyMetricsMiddleware = (metrics: MetricsGatherer) => {
+	return (req: Request, res: Response, next: NextFunction) => {
+		metrics.counter('api_arrival_total', 1, req.metricsLabels);
+		const t0 = process.hrtime();
+		onFinished(res, () => {
+			sampleRequestLatency(metrics, t0, req, res);
+		});
+		next();
+	};
+};

--- a/src/metrics-gatherer.ts
+++ b/src/metrics-gatherer.ts
@@ -5,6 +5,9 @@ import { TypedError } from 'typed-error';
 import * as Debug from 'debug';
 const debug = Debug('node-metrics-gatherer');
 
+import { latencyMetricsMiddleware } from './api-latency';
+import { describeAPIMetricsOnce } from './api-latency-describe';
+
 import {
 	AuthTestFunc,
 	ConstructorMap,
@@ -284,6 +287,12 @@ export class MetricsGatherer {
 	// collect default metrics (underlying prom-client)
 	public collectDefaultMetrics() {
 		prometheus.collectDefaultMetrics();
+	}
+
+	// collect generic API metrics given an express app
+	public collectAPIMetrics(app: express.Application) {
+		describeAPIMetricsOnce(this);
+		app.use(latencyMetricsMiddleware(this));
 	}
 
 	// get the prometheus output

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
 	"extends": "./tsconfig.json",
 	"include": [
-		"src/**/*.ts"
+		"src/**/*.ts",
+		"typings/**/*.d.ts"
 	]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
 	"extends": "./tsconfig.json",
 	"include": [
-		"src/**/*.ts",
+		"src/**/*.ts"
 	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
 	},
 	"include": [
 		"src/**/*.ts",
-		"test/**/*.ts"
+		"test/**/*.ts",
+		"typings/**/*.d.ts"
 	],
 	"exclude": [
 		"node_modules"

--- a/typings/express-extension.d.ts
+++ b/typings/express-extension.d.ts
@@ -1,0 +1,9 @@
+// Augment express.js with metrics-specific attributes via declaration merging.
+/* tslint:disable-next-line:no-namespace */
+declare namespace Express {
+	export interface Request {
+		aborted?: boolean;
+		queueFailState?: 'timed-out' | 'rejected';
+		metricsLabels?: LabelSet;
+	}
+}


### PR DESCRIPTION
This will allow us to factor out a lot of metrics code from the API itself, and also to begin tracking API metrics for builder and other services (anywhere we have an express app).

Change-type: minor
Signed-off-by: dt-rush <nickp@balena.io>