### PR TITLE
expose underlying client so underlying original functions are still available if our semantics are different

### DIFF
--- a/src/metrics-gatherer.ts
+++ b/src/metrics-gatherer.ts
@@ -41,10 +41,12 @@ export class MetricsGatherer {
 	public meta: MetricsMetaMap;
 	private metrics: MetricsMap;
 	public describe: Describer;
+	public client: any;
 
 	constructor() {
 		this.initState();
 		this.setupDescribe();
+		this.client = prometheus;
 	}
 
 	private initState() {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -13,6 +13,12 @@ const expectToErr = (f: () => void) => {
 	expect(metrics.internalErrorCount - errsBefore).to.equal(1);
 };
 
+describe('Client Passthrough', () => {
+	it('method on client should be accessible (check exponentialBuckets)`', () => {
+		expect(metrics.client.exponentialBuckets(1, 2, 3)).to.eql([1, 2, 4]);
+	});
+});
+
 describe('Error', () => {
 	it('should fail if same name used for different kinds', () => {
 		expectToErr(() => {


### PR DESCRIPTION
Change-type: minor
Signed-off-by: dt-rush <nickp@balena.io>