### PR TITLE
exportOn() to have default path /metrics, requiring only port

### DIFF
--- a/src/metrics-gatherer.ts
+++ b/src/metrics-gatherer.ts
@@ -261,7 +261,7 @@ export class MetricsGatherer {
 	// requesthandler
 	public exportOn(
 		port: number,
-		path: string,
+		path: string = '/metrics',
 		requestHandler?: express.Handler,
 	) {
 		const app = express();


### PR DESCRIPTION
Change-type: minor
Signed-off-by: dt-rush <nickp@balena.io>