### PR TITLE
Respect the expected kind when checking for existence in `ensureExists`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "out/index.js",
   "types": "out/index.d.ts",
   "scripts": {
-    "test": "npm run lint && npm run prepare && TS_NODE_FILES=true mocha --exit -r ts-node/register/transpile-only test/*.spec.ts",
+    "test": "npm run lint && npm run prepare && mocha --exit -r ts-node/register/transpile-only test/*.spec.ts",
     "build": "npx tsc --project ./tsconfig.build.json",
     "prettify": "balena-lint --fix src/ test/",
     "lint:typescript": "balena-lint src/ test/ && tsc --noEmit",

--- a/src/metrics-gatherer.ts
+++ b/src/metrics-gatherer.ts
@@ -9,7 +9,6 @@ import { collectAPIMetrics } from './collectors/api/collect';
 
 import {
 	AuthTestFunc,
-	ConstructorMap,
 	CustomParams,
 	Kind,
 	LabelSet,
@@ -20,7 +19,7 @@ import {
 
 export class MetricsGathererError extends TypedError {}
 
-const constructors: ConstructorMap = {
+const constructors = {
 	gauge: new MetricConstructor(prometheus.Gauge),
 	counter: new MetricConstructor(prometheus.Counter),
 	summary: new MetricConstructor(prometheus.Summary),
@@ -40,12 +39,11 @@ export class MetricsGatherer {
 	public meta: MetricsMetaMap;
 	private metrics: MetricsMap;
 	public describe: Describer;
-	public client: any;
+	public client = prometheus;
 
 	constructor() {
 		this.initState();
 		this.setupDescribe();
-		this.client = prometheus;
 	}
 
 	private initState() {

--- a/src/metrics-gatherer.ts
+++ b/src/metrics-gatherer.ts
@@ -102,14 +102,15 @@ export class MetricsGatherer {
 			// ensure either that this metric already exists, or if not
 			// create either a counter if `_total` suffix is found, or
 			// a gauge otherwise
-			const kind = /.+_total$/.test(name) ? 'counter' : 'gauge';
+			const kind =
+				this.meta[name]?.kind ?? (/.+_total$/.test(name) ? 'counter' : 'gauge');
 			this.ensureExists(kind, name, labels);
 			if (!this.checkMetricType(name, ['gauge', 'counter'])) {
 				throw new MetricsGathererError(
 					`Tried to increment non-gauge, non-counter metric ${name}`,
 				);
 			}
-			if (this.meta[name].kind === 'gauge') {
+			if (kind === 'gauge') {
 				this.metrics.gauge[name].inc(labels, val);
 			} else {
 				this.metrics.counter[name].inc(labels, val);
@@ -202,7 +203,7 @@ export class MetricsGatherer {
 		}
 	}
 
-	public exists(name: string) {
+	public exists(name: string): boolean {
 		return this.getMetric(name) != null;
 	}
 
@@ -213,35 +214,31 @@ export class MetricsGatherer {
 		labels: LabelSet = {},
 		customParams: CustomParams = {},
 	) {
-		try {
-			// if exists, bail early
-			if (this.exists(name)) {
-				return;
-			}
-			// if no meta, describe by default to satisfy prometheus
-			if (!this.meta[name]) {
-				this.describe[kind](name, `undescribed ${kind} metric`, {
-					labelNames: Object.keys(labels),
-					...customParams,
-				});
-			} else if (this.meta[name].kind !== kind) {
-				// if name already associated with another kind, throw error
-				throw new MetricsGathererError(
-					`tried to use ${name} twice - first as ` +
-						`${this.meta[name].kind}, then as ${kind}`,
-				);
-			}
-			// create prometheus.Metric instance
-			this.metrics[kind][name] = constructors[kind].create({
-				name,
-				help: this.meta[name].help,
+		// if exists, bail early
+		if (this.metrics[kind][name] != null) {
+			return;
+		}
+		// if no meta, describe by default to satisfy prometheus
+		if (!this.meta[name]) {
+			this.describe[kind](name, `undescribed ${kind} metric`, {
 				labelNames: Object.keys(labels),
 				...customParams,
-				...this.meta[name].customParams,
 			});
-		} catch (e) {
-			this.err(e);
+		} else if (this.meta[name].kind !== kind) {
+			// if name already associated with another kind, throw error
+			throw new MetricsGathererError(
+				`tried to use ${name} twice - first as ` +
+					`${this.meta[name].kind}, then as ${kind}`,
+			);
 		}
+		// create prometheus.Metric instance
+		this.metrics[kind][name] = constructors[kind].create({
+			name,
+			help: this.meta[name].help,
+			labelNames: Object.keys(labels),
+			...customParams,
+			...this.meta[name].customParams,
+		});
 	}
 
 	// reset the metrics or only a given metric if name supplied

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,15 +14,14 @@ export interface CustomParams {
 	aggregator?: AggregatorStrategy;
 }
 // weird class to allow polymorphism over constructors yielding type Metric
-export class MetricConstructor<T extends string = string> {
-	constructor(public construct: new (...args: any[]) => prometheus.Metric<T>) {}
-	public create(...args: any[]): prometheus.Metric<T> {
+export class MetricConstructor<
+	T extends string = string,
+	U extends any[] = any[],
+> {
+	constructor(public construct: new (...args: U) => prometheus.Metric<T>) {}
+	public create(...args: U): prometheus.Metric<T> {
 		return new this.construct(...args);
 	}
-}
-
-export interface ConstructorMap {
-	[kind: string]: MetricConstructor;
 }
 
 export interface MetricsMap<T extends string = string> {


### PR DESCRIPTION
This avoids a potential issue where the metric name was created for a
different metric kind and would be treated as existing but accessing it
would fail. This should also be more performant due to avoiding the
need for the indirect lookups

Change-type: patch