### PR TITLE
Add missing await

### DIFF
--- a/src/metrics-gatherer.ts
+++ b/src/metrics-gatherer.ts
@@ -269,12 +269,12 @@ export class MetricsGatherer {
 
 	// create an express request handler given an auth test function
 	public requestHandler(authTest?: AuthTestFunc): express.Handler {
-		return (req: express.Request, res: express.Response) => {
+		return async (req: express.Request, res: express.Response) => {
 			if (authTest && !authTest(req)) {
 				return res.status(403).send();
 			}
 			res.writeHead(200, { 'Content-Type': 'text/plain' });
-			res.end(prometheus.register.metrics());
+			res.end(await prometheus.register.metrics());
 		};
 	}
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Looking into the cause of `socket hang up` errors when attempting to update to the latest version of `node-metrics-gatherer` in https://github.com/product-os/jellyfish-metrics/pull/927