### PR TITLE
Fix express typing extensions

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -8,6 +8,11 @@ on:
     types: [opened, synchronize, closed]
     branches: [main, master]
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone

--- a/src/collectors/api/collect.ts
+++ b/src/collectors/api/collect.ts
@@ -76,7 +76,9 @@ export const collectAPIMetrics = (
 			req._metrics_gatherer.labels.state = req.aborted
 				? 'aborted'
 				: 'completed';
-			req._metrics_gatherer.labels.statusCode = res.statusCode || '';
+			req._metrics_gatherer.labels.statusCode = res.statusCode
+				? String(res.statusCode)
+				: '';
 			for (const f of onFinishFuncs) {
 				f();
 			}

--- a/typings/extensions.d.ts
+++ b/typings/extensions.d.ts
@@ -1,11 +1,13 @@
-/* tslint:disable-next-line:no-namespace */
-declare namespace Express {
-	export interface Request {
-		// missing from type signature exposed by @types/express
-		aborted: boolean;
-		_metrics_gatherer: {
-			labels?: import('./src/types').LabelSet;
-		};
+import type { LabelSet } from '../src/types';
+
+declare global {
+	/* tslint:disable-next-line:no-namespace */
+	namespace Express {
+		export interface Request {
+			_metrics_gatherer: {
+				labels: LabelSet;
+			};
+		}
 	}
 }
 


### PR DESCRIPTION
Change-type: patch

---

Currently master is failing: https://github.com/balena-io-modules/node-metrics-gatherer/actions/runs/27937180785/job/82661762440?pr=71

```
> npx tsc --project ./tsconfig.build.json

Error: src/collectors/api/collect.ts(19,18): error TS2339: Property '_metrics_gatherer' does not exist on type 'Socket'.
Error: src/collectors/api/collect.ts(33,19): error TS2339: Property '_metrics_gatherer' does not exist on type 'Socket'.
Error: src/collectors/api/collect.ts(35,19): error TS2339: Property '_metrics_gatherer' does not exist on type 'Socket'.
Error: src/collectors/api/collect.ts(40,19): error TS2339: Property '_metrics_gatherer' does not exist on type 'Socket'.
Error: src/collectors/api/collect.ts(41,19): error TS2339: Property '_metrics_gatherer' does not exist on type 'Socket'.
```

Including flowzone id-token changes in this PR as well so the `Publish npm` step can run