### PR TITLE
Remove express dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,27 @@ metrics.gauge('temperature', 28);
 
 ### Exporting metrics (simple)
 
-Then, you need to make sure the metrics can be served when a request arrives, either on an existing express app, or creating a dedicated express app listening on a given port:
+Then, you need to make sure the metrics can be served when a request arrives.
+This library does not depend on express at runtime - instead it provides a
+request handler which you mount on your own express app (or a dedicated one you
+create just for metrics):
 
 ```
-// create a request handler to respond to prometheus pulls, given an
-// already-existing express app
+// create a request handler to respond to prometheus pulls, and mount it on
+// your express app
 app.use('/metrics', metrics.requestHandler());
 
-// OR, create our own app (using port 9337, arbitrarily)
-metrics.exportOn(9337, '/metrics');
+// OR, create a dedicated app just for metrics (using port 9337, arbitrarily)
+import express from 'express';
+express().use('/metrics', metrics.requestHandler()).listen(9337);
 ```
 
-Optionally, you can provide a function which validates whether the requeest should
+Optionally, you can provide a function which validates whether the request should
 be served or given a 403, by returning a boolean (an "authFunc"):
 
 ```
-const authFunc = (req) => req.get('Authorization') === 'Basic 123456');
+const authFunc = (req) => req.get('Authorization') === 'Basic 123456';
 app.use('/metrics', metrics.requestHandler(authFunc));
-
-// OR, if creating our own app (using port 9337, arbitrarily)
-metrics.exportOn(9337, '/metrics', metrics.requestHandler(authFunc));
 ```
 
 ## Exporting metrics (cluster)
@@ -59,7 +60,9 @@ if (cluster.isMaster) {
 	for (let i = 0; i < 4; i++) {
 		cluster.fork();
 	}
-	metrics.listenAndExport(9337, '/cluster_metrics', metrics.aggregateRequestHandler());
+	express()
+		.use('/cluster_metrics', metrics.aggregateRequestHandler())
+		.listen(9337);
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,21 +20,24 @@
   "license": "ISC",
   "dependencies": {
     "@types/debug": "^4.1.7",
-    "@types/express": "^4.17.13",
     "@types/on-finished": "^2.3.1",
     "debug": "^4.3.4",
-    "express": "^4.17.3",
     "on-finished": "^2.4.1",
     "prom-client": "^15.1.3",
     "typed-error": "^3.2.1"
+  },
+  "peerDependencies": {
+    "@types/express": "^4.17.21 || ^5.0.0"
   },
   "devDependencies": {
     "@balena/lint": "^9.3.8",
     "@types/chai": "^4.3.0",
     "@types/chai-http": "^4.2.0",
+    "@types/express": "^5.0.6",
     "@types/mocha": "^10.0.10",
     "chai": "^4.3.6",
     "chai-http": "^4.3.0",
+    "express": "^5.2.1",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
     "mocha": "^11.7.4",

--- a/src/metrics-gatherer.ts
+++ b/src/metrics-gatherer.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import type express from 'express';
 import prometheus from 'prom-client';
 import { TypedError } from 'typed-error';
 
@@ -254,18 +254,6 @@ export class MetricsGatherer {
 		} catch (e) {
 			this.err(e);
 		}
-	}
-
-	// create an express app listening on a given port, responding with the given
-	// requesthandler
-	public exportOn(
-		port: number,
-		path = '/metrics',
-		requestHandler?: express.Handler,
-	) {
-		const app = express();
-		app.use(path, requestHandler ?? this.requestHandler());
-		app.listen(port);
 	}
 
 	// create an express request handler given an auth test function


### PR DESCRIPTION
The library now requires the caller to use
their copy of express to make use of the
request handler this library provides.

Change-type: major

---

Tested in https://github.com/balena-io/balena-delta/pull/801